### PR TITLE
Update Authentication file to include a more user friendly message for password change

### DIFF
--- a/app/scripts/Authentication.js
+++ b/app/scripts/Authentication.js
@@ -931,21 +931,6 @@ let Authentication = (function () {
                     /*
                      * For some reason, we sometimes the this error back, but simply retrying then works. So if we get
                      * this error, retry one time.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
                      */
                     if (err.code === 'NotAuthorizedException' && err.message.startsWith('Logins don\'t match') && retryCount === 0) {
                         alerter.notify('Retrying...');

--- a/app/scripts/Authentication.js
+++ b/app/scripts/Authentication.js
@@ -763,10 +763,14 @@ let Authentication = (function () {
 
             }, function rejected(err) {
                 // There was an error. Show it, but don't close the dialog.
-                alerter.error(err.message || 'Error changing password.');
+                // This is the message that Amazon returns when a user enters a new password with less than 6 characters: "1 validation error detected: Value at 'proposedPassword' failed to satisfy constraint: Member must have length greater than or equal to 6"
+                //Substituting this with a more user-friendly message
+                let msg=err.message || 'Error changing password.'
+                if (err.message && err.message.includes("Member must have length greater than or equal to 6")) {
+                    msg ='New password must have at least 6 characters'
+                }
+                alerter.error(msg);
             });
-
-
         });
 
         fixTabOrdering($dialog);
@@ -927,6 +931,21 @@ let Authentication = (function () {
                     /*
                      * For some reason, we sometimes the this error back, but simply retrying then works. So if we get
                      * this error, retry one time.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
                      */
                     if (err.code === 'NotAuthorizedException' && err.message.startsWith('Logins don\'t match') && retryCount === 0) {
                         alerter.notify('Retrying...');


### PR DESCRIPTION
Updating default error message from Amazon for password change to a more user friendly message when new password does not meet requirement: "New password must be at least 6 characters long"